### PR TITLE
add receiving validation plugin results to the bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ window.pluginBridge.register({
   },
   receiveSession: (session) => {
     // session information including session annotations
+  },
+  receiveValidation: (results) => {
+    // validation results from the validation plugins
   }
 });
 ```
@@ -100,6 +103,17 @@ Currently, Project Griffon UI will send all events via this method on all regist
 ##### receiveSelectedEvents
 
 Project Griffon UI sends an array of event uuids selected from the result of a plugin calling `selectEvents` on the bridge.
+
+##### receiveValidation
+
+The parent (Project Griffon UI) calls receiveValidation when the validation plugins have been executed. The payload will contain an object of results each keyed by the namespace of the plugin. Each result will have the following payload:
+
+```
+{
+  "message": "All your base are belong to us",
+  "errors": ["uuid1", "uuid2"], // list of event uuids where a problem was discovered
+}
+``` 
 
 ## Scripts
 

--- a/src/child.js
+++ b/src/child.js
@@ -11,15 +11,17 @@ governing permissions and limitations under the License.
 
 import connectToParent from 'penpal/lib/connectToParent';
 
-let pluginViewMethods = {};
+const NOOP = () => {};
+
+let viewPluginMethods = {};
 
 const getPluginMethod = (name) => {
-  const method = pluginViewMethods[name];
+  const method = viewPluginMethods[name];
   if (!method) {
     throw new Error(`Unable to call ${name}. The plugin must register a ${name} function using pluginBridge.register().`);
   }
 
-  return method.bind(pluginViewMethods);
+  return method.bind(viewPluginMethods);
 };
 
 const init = (...args) => {
@@ -34,6 +36,10 @@ const receiveEvents = (...args) => {
   getPluginMethod('receiveEvents')(...args);
 };
 
+const receivePlugins = (...args) => {
+  getPluginMethod('receivePlugins')(...args);
+};
+
 const receiveSelectedEvents = (...args) => {
   getPluginMethod('receiveSelectedEvents')(...args);
 };
@@ -42,8 +48,8 @@ const receiveSession = (...args) => {
   getPluginMethod('receiveSession')(...args);
 };
 
-const receivePlugins = (...args) => {
-  getPluginMethod('receivePlugins')(...args);
+const receiveValidation = (...args) => {
+  getPluginMethod('receiveValidation')(...args);
 };
 
 const connectionPromise = connectToParent({
@@ -53,7 +59,8 @@ const connectionPromise = connectToParent({
     receiveEvents,
     receiveSelectedEvents,
     receiveSession,
-    receivePlugins
+    receivePlugins,
+    receiveValidation
   }
 }).promise;
 
@@ -72,7 +79,9 @@ const pluginBridge = {
   deletePlugin: getParentMethod('deletePlugin'),
   navigateTo: getParentMethod('navigateTo'),
   register: (methods) => {
-    pluginViewMethods = {
+    viewPluginMethods = {
+      navigateTo: NOOP,
+      receiveValidation: NOOP,
       ...methods
     };
     connectionPromise.then(parent => parent.pluginRegistered());

--- a/src/parent.js
+++ b/src/parent.js
@@ -65,7 +65,7 @@ export const loadIframe = (options) => {
     debug = false,
     deletePlugin,
     iframe,
-    navigateTo,
+    navigateTo = NOOP,
     pluginInitOptions,
     renderTimeoutDuration = RENDER_TIMEOUT_DURATION,
     uploadPlugin,
@@ -95,9 +95,10 @@ export const loadIframe = (options) => {
                 init: child.init,
                 navigateTo: child.navigateTo,
                 receiveEvents: child.receiveEvents,
+                receivePlugins: child.receivePlugins,
                 receiveSelectedEvents: child.receiveSelectedEvents,
                 receiveSession: child.receiveSession,
-                receivePlugins: child.receivePlugins
+                receiveValidation: child.receiveValidation
               });
             }).catch((error) => {
               clearTimeout(renderTimeoutId);

--- a/test/module/fixtures/griffonAPIs.html
+++ b/test/module/fixtures/griffonAPIs.html
@@ -7,6 +7,7 @@
     <script>
       pluginBridge.register({
         init: function(info) {},
+        navigateTo: function() {},
         receiveEvents: function() {
           console.log('receiveEvents');
           pluginBridge.annotateEvent()
@@ -18,7 +19,8 @@
           pluginBridge.uploadPlugin()
         },
         receiveSelectedEvents: function() {},
-        receiveSession: function() {}
+        receiveSession: function() {},
+        receiveValidation: function() {}
       });
     </script>
   </head>

--- a/test/module/fixtures/optional.html
+++ b/test/module/fixtures/optional.html
@@ -7,16 +7,13 @@
     <script>
       pluginBridge.register({
         init: function(info) {},
-        navigateTo: function() {},
         receiveEvents: function() {},
-        receivePlugins: function() {},
         receiveSelectedEvents: function() {},
         receiveSession: function() {},
-        receiveValidation: function() {}
       });
     </script>
   </head>
   <body>
     Iframe
   </body>
-</html>
+</html> 

--- a/test/module/pluginBridge.spec.js
+++ b/test/module/pluginBridge.spec.js
@@ -38,9 +38,23 @@ describe('parent', () => {
       expect(child.init).toEqual(jasmine.any(Function));
       expect(child.navigateTo).toEqual(jasmine.any(Function));
       expect(child.receiveEvents).toEqual(jasmine.any(Function));
+      expect(child.receivePlugins).toEqual(jasmine.any(Function));
       expect(child.receiveSelectedEvents).toEqual(jasmine.any(Function));
       expect(child.receiveSession).toEqual(jasmine.any(Function));
-      expect(child.receivePlugins).toEqual(jasmine.any(Function));
+      expect(child.receiveValidation).toEqual(jasmine.any(Function));
+      done();
+    });
+  });
+
+  it('loads an iframe and provides noop APIs', (done) => {
+    bridge = createAndLoadIframe('optional.html');
+
+    expect(bridge.destroy).toEqual(jasmine.any(Function));
+    expect(bridge.promise).toEqual(jasmine.any(Promise));
+
+    bridge.promise.then((child) => {
+      expect(child.navigateTo).toEqual(jasmine.any(Function));
+      expect(child.receiveValidation).toEqual(jasmine.any(Function));
       done();
     });
   });
@@ -73,7 +87,7 @@ describe('parent', () => {
     bridge = createAndLoadIframe('connectionFailure.html');
 
     bridge.promise.then(() => {}, (err) => {
-      expect(err).toBe(ERROR_CODES.CONNECTION_TIMEOUT);
+      expect(err.toString()).toContain(ERROR_CODES.CONNECTION_TIMEOUT);
       jasmine.clock().uninstall();
       done();
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding receiveValidation to the bridge

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Validation Plugins are executed in an iFrame and the results are aggregated and sent to the Project Griffon UI. The results can be sent to View plugins to display information, notices, course of actions, etc. to the end user.

## How Has This Been Tested?

Added to module tests and tested in the Project Griffon UI integration environment tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
