### PR TITLE
configure receivePlugins as a noop

### DIFF
--- a/src/child.js
+++ b/src/child.js
@@ -81,6 +81,7 @@ const pluginBridge = {
   register: (methods) => {
     viewPluginMethods = {
       navigateTo: NOOP,
+      receivePlugins: NOOP,
       receiveValidation: NOOP,
       ...methods
     };

--- a/test/module/fixtures/griffonAPIs.html
+++ b/test/module/fixtures/griffonAPIs.html
@@ -9,7 +9,6 @@
         init: function(info) {},
         navigateTo: function() {},
         receiveEvents: function() {
-          console.log('receiveEvents');
           pluginBridge.annotateEvent()
           pluginBridge.annotateSession()
           pluginBridge.deletePlugin()

--- a/test/module/pluginBridge.spec.js
+++ b/test/module/pluginBridge.spec.js
@@ -53,9 +53,13 @@ describe('parent', () => {
     expect(bridge.promise).toEqual(jasmine.any(Promise));
 
     bridge.promise.then((child) => {
-      expect(child.navigateTo).toEqual(jasmine.any(Function));
-      expect(child.receiveValidation).toEqual(jasmine.any(Function));
-      done();
+      Promise.all([
+        child.navigateTo(),
+        child.receivePlugins(),
+        child.receiveValidation()
+      ]).then(() => {
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change receivePlugins to a no-op so it isn't required by plugins to implement if they so choose.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The Project Griffon UI won't throw errors if the plugin does not implement receivePlugins

## How Has This Been Tested?

Locally and with added tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
