### PR TITLE
Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ Project Griffon UI sends an array of connections. A connection will look like:
 {
   namespace, // the namespace of the connector
   context, // object containing parameters needed to run the connector
-  query: { isLoaded, loading, error }, // defines the state of the remote api query
+  loaded, // has the connection data finished loading
+  loading, // is the connection currently loading
+  error, // error object resulting from the query (if applicable)
   data // the resulting data from the api call
 }
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Allows a plugin to annotate an event. Annotations are additional data to events 
 
 Allows a plugin to annotate a session.
 
+##### flushConnection
+
+Allows a plugin to rerun a connector. Flush connection takes a `namespace` and  `context` parameter. The exact connection that fully matches both the `namespace` and `context` will be cleared, causing the downstream Connector to reload the data.
+
 ##### deletePlugin
 
 Allows a plugin to delete a validation or view plugin that is owned by the user's organization. The payload needs to be the uuid of a plugin. This operation is currently restricted to Adobe first-party plugins only.
@@ -147,6 +151,18 @@ Example Payload
 ##### navigateTo
 
 The parent (Project Griffon UI) calls navigateTo whenever the URL is updated. The intent here is to provide deep linking capabilities as well as an opportunity for plugins to be good citizens and limit resources when not visible.
+
+##### receiveConnections
+
+Project Griffon UI sends an array of connections. A connection will look like:
+```
+{
+  namespace, // the namespace of the connector
+  context, // object containing parameters needed to run the connector
+  query: { isLoaded, loading, error }, // defines the state of the remote api query
+  data // the resulting data from the api call
+}
+```
 
 ##### receiveEvents
 

--- a/src/child.js
+++ b/src/child.js
@@ -87,10 +87,12 @@ const pluginBridge = {
   annotateEvent: getParentMethod('annotateEvent'),
   annotateSession: getParentMethod('annotateSession'),
   deletePlugin: getParentMethod('deletePlugin'),
+  flushConnection: getParentMethod('flushConnection'),
   navigateTo: getParentMethod('navigateTo'),
   register: (methods) => {
     viewPluginMethods = {
       navigateTo: NOOP,
+      receiveConnections: NOOP,
       receivePlugins: NOOP,
       receiveSettings: NOOP,
       receiveValidation: NOOP,

--- a/src/child.js
+++ b/src/child.js
@@ -32,6 +32,10 @@ const navigateTo = (...args) => {
   getPluginMethod('navigateTo')(...args);
 };
 
+const receiveConnections = (...args) => {
+  getPluginMethod('receiveConnections')(...args);
+};
+
 const receiveEvents = (...args) => {
   getPluginMethod('receiveEvents')(...args);
 };
@@ -60,6 +64,7 @@ const connectionPromise = connectToParent({
   methods: {
     init,
     navigateTo,
+    receiveConnections,
     receiveEvents,
     receivePlugins,
     receiveSelectedEvents,

--- a/src/parent.js
+++ b/src/parent.js
@@ -94,6 +94,7 @@ export const loadIframe = (options) => {
                 // initialize multiple times with different info.
                 init: child.init,
                 navigateTo: child.navigateTo,
+                receiveConnections: child.receiveConnections,
                 receiveEvents: child.receiveEvents,
                 receivePlugins: child.receivePlugins,
                 receiveSelectedEvents: child.receiveSelectedEvents,

--- a/src/parent.js
+++ b/src/parent.js
@@ -40,6 +40,8 @@ let destroy;
  * the returned promise with a CONNECTION_TIMEOUT error code.
  * @param {Function} [options.deletePlugin] The function to call when a view wants to delete a
  * plugin.
+ * @param {Function} [options.flushConnection] The function to call when a view needs to reload
+ * connection data.
  * @param {string} options.iframe The iframe loading the plugin.
  * @param {Function} [options.navigateTo] The function to call when a plugin view wants to
  * navigate to another plugin view for deep linking
@@ -64,6 +66,7 @@ export const loadIframe = (options) => {
     connectionTimeoutDuration = CONNECTION_TIMEOUT_DURATION,
     debug = false,
     deletePlugin,
+    flushConnection = NOOP,
     iframe,
     navigateTo = NOOP,
     pluginInitOptions,
@@ -84,6 +87,7 @@ export const loadIframe = (options) => {
         annotateSession,
         navigateTo,
         deletePlugin,
+        flushConnection,
         pluginRegistered: () => {
           connection.promise.then((child) => {
             child.init(pluginInitOptions).then(() => {

--- a/test/module/fixtures/griffonAPIs.html
+++ b/test/module/fixtures/griffonAPIs.html
@@ -12,6 +12,7 @@
           pluginBridge.annotateEvent()
           pluginBridge.annotateSession()
           pluginBridge.deletePlugin()
+          pluginBridge.flushConnection()
           pluginBridge.navigateTo()
           pluginBridge.selectEvents()
           pluginBridge.sendCommand()

--- a/test/module/pluginBridge.spec.js
+++ b/test/module/pluginBridge.spec.js
@@ -37,6 +37,7 @@ describe('parent', () => {
     bridge.promise.then((child) => {
       expect(child.init).toEqual(jasmine.any(Function));
       expect(child.navigateTo).toEqual(jasmine.any(Function));
+      expect(child.receiveConnections).toEqual(jasmine.any(Function));
       expect(child.receiveEvents).toEqual(jasmine.any(Function));
       expect(child.receivePlugins).toEqual(jasmine.any(Function));
       expect(child.receiveSelectedEvents).toEqual(jasmine.any(Function));

--- a/test/module/pluginBridge.spec.js
+++ b/test/module/pluginBridge.spec.js
@@ -116,6 +116,7 @@ describe('parent', () => {
     let annotateEvent;
     let annotateSession;
     let deletePlugin;
+    let flushConnection;
     let navigateTo;
     let selectEvents;
     let sendCommand;
@@ -125,6 +126,7 @@ describe('parent', () => {
       annotateEvent = jasmine.createSpy();
       annotateSession = jasmine.createSpy();
       deletePlugin = jasmine.createSpy();
+      flushConnection = jasmine.createSpy();
       navigateTo = jasmine.createSpy();
       selectEvents = jasmine.createSpy();
       sendCommand = jasmine.createSpy();
@@ -136,6 +138,7 @@ describe('parent', () => {
         annotateEvent,
         annotateSession,
         deletePlugin,
+        flushConnection,
         navigateTo,
         selectEvents,
         sendCommand,
@@ -147,6 +150,7 @@ describe('parent', () => {
           expect(annotateEvent).toHaveBeenCalled();
           expect(annotateSession).toHaveBeenCalled();
           expect(deletePlugin).toHaveBeenCalled();
+          expect(flushConnection).toHaveBeenCalled();
           expect(navigateTo).toHaveBeenCalled();
           expect(selectEvents).toHaveBeenCalled();
           expect(sendCommand).toHaveBeenCalled();
@@ -164,6 +168,7 @@ describe('parent', () => {
           expect(annotateEvent).not.toHaveBeenCalled();
           expect(annotateSession).not.toHaveBeenCalled();
           expect(deletePlugin).not.toHaveBeenCalled();
+          expect(flushConnection).not.toHaveBeenCalled();
           expect(navigateTo).not.toHaveBeenCalled();
           expect(selectEvents).not.toHaveBeenCalled();
           expect(sendCommand).not.toHaveBeenCalled();


### PR DESCRIPTION
## Description

Add methods to support connections:

`receiveConnections` will receive an array of connection objects containing the query status and the results
`flushConnection` is used by the ui plugin to manually reset a connection. Could run after an api occurs or from a "Refresh" button of sorts

## Motivation and Context

Using connections, we no longer need to have a bunch of APIs run in the UIs. A Connector can retrieve the data then pass it into the view plugins. View plugins now can just worry about displaying data.

## How Has This Been Tested?

Tests were updated

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
